### PR TITLE
instead of reading env value from process, read it from .env file

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ const http = require('http');
 const https = require('https');
 const crypto = require('crypto');
 const Path = require("path");
+const dotenv = require("dotenv")
+dotenv.config()
 const httpPort = process.env.PORT || 5656;
 const httpsPort = process.env.PORT_HTTPS || 5657;
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "memjs": "^1.3.0",
     "nsfwjs": "^2.3.0",
     "redis": "^4.0.0-rc.1",
-    "seedrandom": "^2.4.4"
+    "seedrandom": "^2.4.4",
     "dotenv": "^16.0.1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "nsfwjs": "^2.3.0",
     "redis": "^4.0.0-rc.1",
     "seedrandom": "^2.4.4"
+    "dotenv": "^16.0.1"
   },
   "repository": {
     "url": "https://glitch.com/edit/#!/hello-express"


### PR DESCRIPTION
why? im sure user (if any) wont like big command just to setup redis/change port/etc